### PR TITLE
Hardened and add tests for Server

### DIFF
--- a/message.go
+++ b/message.go
@@ -143,6 +143,7 @@ func (m *MBAP) MarshalBinary() ([]byte, error) {
 
 // Request is a Modbus request.
 type Request struct {
+	// Request is a Modbus request.
 	MBAP
 
 	FunctionCode uint8

--- a/server.go
+++ b/server.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/binary"
 	"fmt"
+	"io"
 	"log"
 	"net"
 )
@@ -13,6 +14,8 @@ import (
 type Server struct {
 	l        net.Listener
 	handlers map[uint8]Handler
+
+	ErrorLog *log.Logger
 }
 
 // NewServer creates a new server on given address.
@@ -33,55 +36,88 @@ func (s *Server) Listen() {
 	for {
 		conn, err := s.l.Accept()
 		if err != nil {
-			log.Fatal(err)
+			s.logf("golfish: failed to accept incomming connection: %v", err)
+			continue
 		}
 
-		go s.handleConn(conn)
+		go func() {
+			if err := s.handleConn(conn); err != nil {
+				s.logf("goldfish: unable to handle request from %v: %v", conn.RemoteAddr(), err)
+
+			}
+			if err := conn.Close(); err != nil {
+				s.logf("goldfish: failed to close connection with %v: %v", conn.RemoteAddr(), err)
+			}
+		}()
 	}
 }
 
-func (s *Server) handleConn(conn net.Conn) {
-	defer func() {
-		if err := conn.Close(); err != nil {
-			log.Printf("Failed to  close connection with client: %v", err)
-		}
-	}()
+func (s *Server) handleConn(conn io.ReadWriteCloser) error {
 	r := bufio.NewReader(conn)
+	for {
+		buf, err := s.readMessage(r)
+		if err != nil {
+			return fmt.Errorf("failed to read message from connection: %v", err)
+		}
 
+		var req Request
+		if err := req.UnmarshalBinary(buf); err != nil {
+			return fmt.Errorf("failed to parse request: %v", err)
+		}
+
+		if err := s.executeAndRespond(conn, &req); err != nil {
+			return fmt.Errorf("something went horribly wrong and server has to close connection: %v", err)
+		}
+	}
+}
+
+func (s *Server) readMessage(r *bufio.Reader) ([]byte, error) {
 	b, err := r.Peek(6)
+	if err != nil {
+		return nil, fmt.Errorf("failed to peek into message: %v", err)
+	}
 	length := binary.BigEndian.Uint16(b[4:6])
 
 	buf := make([]byte, 6+length)
 	_, err = r.Read(buf)
 
 	if err != nil {
-		return
+		return nil, fmt.Errorf("failed to read request: %v", err)
 	}
 
-	var req Request
-	if err := req.UnmarshalBinary(buf); err != nil {
-		log.Printf("Failed to parse request: %v", err)
-		return
-	}
+	return buf, nil
 
+}
+
+func (s *Server) executeAndRespond(conn io.Writer, req *Request) error {
 	h, ok := s.handlers[req.FunctionCode]
 	if ok {
-		h.ServeModbus(conn, req)
-		return
+		h.ServeModbus(conn, *req)
+		return nil
 	}
 
-	resp := NewErrorResponse(req, IllegalFunctionError)
+	resp := NewErrorResponse(*req, IllegalFunctionError)
 	data, err := resp.MarshalBinary()
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("failed to create response: %v", err)
 	}
 
 	if _, err := conn.Write(data); err != nil {
-		log.Printf("Failed to write response: %v", err)
+		return fmt.Errorf("failed to write response: %v", err)
 	}
+
+	return nil
 }
 
 // Handle registers the handler for the given function code.
 func (s *Server) Handle(functionCode uint8, h Handler) {
 	s.handlers[functionCode] = h
+}
+
+func (s *Server) logf(format string, args ...interface{}) {
+	if s.ErrorLog != nil {
+		s.ErrorLog.Printf(format, args...)
+	} else {
+		log.Printf(format, args...)
+	}
 }

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,122 @@
+package modbus
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ErrorWriter is a writer that always fails to write.
+type ErrorWriter struct{}
+
+func (e ErrorWriter) Write([]byte) (int, error) { return 0, errors.New("") }
+
+type RawHandler struct {
+	handle func(w io.Writer, r Request)
+}
+
+func (h RawHandler) ServeModbus(w io.Writer, r Request) {
+	h.handle(w, r)
+}
+
+// Connection is a struct implemention the io.ReadWriteCloser interface.
+type Connection struct {
+	read  func([]byte) (int, error)
+	write func([]byte) (int, error)
+	close func() error
+}
+
+func (c Connection) Read(b []byte) (int, error) { return c.read(b) }
+
+func (c Connection) Write(b []byte) (int, error) { return c.write(b) }
+
+func (c Connection) Close() error { return c.close() }
+
+func TestListen(t *testing.T) {
+	s := Server{}
+
+	conn := Connection{
+		read: func(b []byte) (int, error) {
+			copy(b, []byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x4, 0x0, 0x0, 0x0})
+			return 6, nil
+		},
+
+		write: func(b []byte) (int, error) {
+			return 0, errors.New("")
+		},
+	}
+
+	err := s.handleConn(conn)
+	assert.NotNil(t, err)
+
+	conn.read = func(b []byte) (int, error) {
+		return 0, errors.New("")
+	}
+
+	err = s.handleConn(conn)
+	assert.NotNil(t, err)
+}
+
+func TestReadMessage(t *testing.T) {
+	s := Server{}
+
+	tests := []struct {
+		data []byte
+	}{
+		{[]byte{}},
+		{[]byte{0x0}},
+		{[]byte{0x0, 0x0}},
+		{[]byte{0x0, 0x0, 0x0}},
+		{[]byte{0x0, 0x0, 0x0, 0x0}},
+		{[]byte{0x0, 0x0, 0x0, 0x0, 0x0}},
+	}
+
+	for _, test := range tests {
+		_, err := s.readMessage(bufio.NewReader(bytes.NewReader(test.data)))
+		assert.NotNil(t, err)
+	}
+
+	data := []byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0}
+	msg, err := s.readMessage(bufio.NewReader(bytes.NewReader(data)))
+
+	assert.Nil(t, err)
+	assert.Equal(t, msg, data)
+}
+
+func TestExecuteAndRespond(t *testing.T) {
+	s, _ := NewServer(":")
+	writer := new(bytes.Buffer)
+	req := &Request{FunctionCode: ReadCoils}
+
+	// Try to execute a non-implemented function code. This fails,
+	// therefore the server tries to send a IllegalFunction exception
+	// response the the client. This should fail too because the writer
+	// fails to write the response.
+	err := s.executeAndRespond(ErrorWriter{}, req)
+	assert.NotNil(t, err)
+
+	// Again trying to execute a non-implemented function code. Now with
+	// a function writer. This should succeed and the bytes making up a
+	// IllegalFunction response should be written on the writer.
+	err = s.executeAndRespond(writer, req)
+
+	assert.Nil(t, err)
+	assert.Equal(t, []byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x3, 0x0, 0x81, 0x1}, writer.Bytes())
+
+	// Try again, but now executing an implemented function code.
+	// Everything should work.
+	h := RawHandler{
+		handle: func(w io.Writer, r Request) {
+			assert.Equal(t, req, &r)
+			assert.Equal(t, writer, w)
+		},
+	}
+
+	s.Handle(ReadCoils, h)
+	err = s.executeAndRespond(writer, req)
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
The Server was prone to error, untested and closed the connection after
receiving 1 message. This has all has been fixed in this commit.

Processing a message on a connection is split up into a few function
calls which are well tested. All calls to panic() are removed.

The Server now has ErrorLog attribute so one can use hook up a Server to
his favorite logging engine.

Issue: #7