### PR TITLE
Add Value type to support unsigned values

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # Goldfish
 
-Goldfish is a Go package for creating Modbus servers. See
+Goldfish is a Go package for creating Modbus TCP servers. See
 [example/main.go][example] for an example.
 
 ## License

--- a/example/main.go
+++ b/example/main.go
@@ -16,10 +16,15 @@ import (
 //
 // The handler must return a slice representing the values of the requested
 // addresses like [0, 1, 0, 1, 0, 1].
-func handleReadCoils(unitID, start, quantity int) ([]int16, error) {
-	coils := make([]int16, quantity)
+func handleReadCoils(unitID, start, quantity int) ([]modbus.Value, error) {
+	coils := make([]modbus.Value, quantity)
 	for i := 0; i < quantity; i++ {
-		coils[i] = int16((i + start) % 2)
+		v, err := modbus.NewValue((i + start) % 2)
+		if err != nil {
+			return coils, modbus.SlaveDeviceFailureError
+		}
+
+		coils[i] = v
 	}
 
 	return coils, nil
@@ -33,20 +38,25 @@ func handleReadCoils(unitID, start, quantity int) ([]int16, error) {
 //
 // The handler must return a slice with the values of the registers like
 // [31, 298, 1999].
-func handleRegisters(unitID, start, quantity int) ([]int16, error) {
-	registers := make([]int16, quantity)
+func handleRegisters(unitID, start, quantity int) ([]modbus.Value, error) {
+	registers := make([]modbus.Value, quantity)
 	for i := 0; i <= quantity; i++ {
-		registers[i] = int16(i)
+		v, err := modbus.NewValue(i)
+		if err != nil {
+			return registers, modbus.SlaveDeviceFailureError
+		}
+
+		registers[i] = v
 	}
 
 	return registers, nil
 }
 
-func handleWriteRegisters(unitID, start int, values []int16) error {
+func handleWriteRegisters(unitID, start int, values []modbus.Value) error {
 	return nil
 }
 
-func handleWriteCoils(unitID, start int, values []int16) error {
+func handleWriteCoils(unitID, start int, values []modbus.Value) error {
 	if start == 1 {
 		return modbus.IllegalAddressError
 	}

--- a/handler.go
+++ b/handler.go
@@ -1,7 +1,6 @@
 package modbus
 
 import (
-	"bytes"
 	"encoding/binary"
 	"io"
 	"log"
@@ -12,14 +11,18 @@ type Handler interface {
 	ServeModbus(w io.Writer, r Request)
 }
 
+// ReadHandlerFunc is an adapter to allow the use of ordinary functions as
+// handlers for Modbus read functions.
+type ReadHandlerFunc func(unitID, start, quantity int) ([]Value, error)
+
 // ReadHandler can be used to respond on Modbus request with function codes
 // 1,2, 3 and 4.
 type ReadHandler struct {
-	handle func(UnitID, start, quantity int) ([]int16, error)
+	handle ReadHandlerFunc
 }
 
 // NewReadHandler creates a new ReadHandler.
-func NewReadHandler(h func(unitID, start, quantity int) ([]int16, error)) *ReadHandler {
+func NewReadHandler(h ReadHandlerFunc) *ReadHandler {
 	return &ReadHandler{
 		handle: h,
 	}
@@ -36,29 +39,24 @@ func (h ReadHandler) ServeModbus(w io.Writer, req Request) {
 		return
 	}
 
-	buf := new(bytes.Buffer)
-
-	var data []interface{}
+	var data []byte
 
 	switch req.FunctionCode {
 	case ReadCoils, ReadDiscreteInputs:
-		for _, v := range reduce(values) {
-			data = append(data, v)
-		}
+		data = append(data, reduce(values)...)
 	default:
 		for _, v := range values {
-			data = append(data, v)
+			b, err := v.MarshalBinary()
+			if err != nil {
+				respond(w, NewErrorResponse(req, SlaveDeviceFailureError))
+				return
+			}
+
+			data = append(data, b...)
 		}
 	}
 
-	for _, v := range data {
-		if err := binary.Write(buf, binary.BigEndian, v); err != nil {
-			respond(w, NewErrorResponse(req, SlaveDeviceFailureError))
-			return
-		}
-	}
-
-	respond(w, NewResponse(req, buf.Bytes()))
+	respond(w, NewResponse(req, data))
 }
 
 func respond(w io.Writer, resp *Response) {
@@ -74,12 +72,12 @@ func respond(w io.Writer, resp *Response) {
 }
 
 // reduce takes slice like [1, 0, 1, 0, 0, 1] and reduces that to a byte.
-func reduce(values []int16) []int8 {
+func reduce(values []Value) []byte {
 	length := len(values) / 8
 	if len(values)%8 > 0 {
 		length++
 	}
-	reduced := make([]int8, length)
+	reduced := make([]byte, length)
 
 	n := length - 1
 
@@ -97,7 +95,7 @@ func reduce(values []int16) []int8 {
 
 		for _, v := range b {
 			reduced[n] = reduced[n] << 1
-			if v > 0 {
+			if v.Get() > 0 {
 				reduced[n] = reduced[n] | 1
 			}
 		}
@@ -108,14 +106,18 @@ func reduce(values []int16) []int8 {
 	return reduced
 }
 
+// WriteHandlerFunc is an adapter to allow the use of ordinary functions as
+// handlers for Modbus write functions.
+type WriteHandlerFunc func(unitID, start int, values []Value) error
+
 // WriteHandler can be used to respond on Modbus request with function codes
 // 5 and 6.
 type WriteHandler struct {
-	handler func(unitID, start int, values []int16) error
+	handler WriteHandlerFunc
 }
 
 // NewWriteHandler creates a new WriteHandler.
-func NewWriteHandler(h func(unitID, start int, values []int16) error) *WriteHandler {
+func NewWriteHandler(h WriteHandlerFunc) *WriteHandler {
 	return &WriteHandler{
 		handler: h,
 	}
@@ -127,28 +129,28 @@ func (h WriteHandler) ServeModbus(w io.Writer, req Request) {
 	var resp *Response
 	start := int(binary.BigEndian.Uint16(req.Data[:2]))
 
-	switch req.FunctionCode {
-	case WriteSingleCoil:
-		v := []int16{int16(binary.BigEndian.Uint16(req.Data[2:4]))}
-		if v[0] != 0 {
-			v[0] = 1
-		}
-		err = h.handler(int(req.UnitID), start, v)
-		if err == nil {
-			resp = NewResponse(req, req.Data)
-		}
-	case WriteSingleRegister:
-		v := []int16{int16(binary.BigEndian.Uint16(req.Data[2:4]))}
-		err = h.handler(int(req.UnitID), start, v)
-		if err == nil {
-			resp = NewResponse(req, req.Data)
+	v, err := NewValue(int(binary.BigEndian.Uint16(req.Data[2:4])))
+	if err != nil {
+		respond(w, NewErrorResponse(req, IllegalDataValueError))
+		return
+	}
+
+	if req.FunctionCode == WriteSingleCoil {
+		if v.Get() != 0 {
+			if err := v.Set(1); err != nil {
+				respond(w, NewErrorResponse(req, IllegalDataValueError))
+				return
+			}
 		}
 	}
+
+	err = h.handler(int(req.UnitID), start, []Value{v})
 
 	if err != nil {
 		respond(w, NewErrorResponse(req, err))
 		return
 	}
 
+	resp = NewResponse(req, req.Data)
 	respond(w, resp)
 }

--- a/message_test.go
+++ b/message_test.go
@@ -6,6 +6,27 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TesTValue(t *testing.T) {
+	tests := []struct {
+		value    int
+		expected []byte
+	}{
+		{19, []byte{0x0, 0x13}},
+		{-128, []byte{0xff, 0x80}},
+		{-2391, []byte{0xf6, 0xa9}},
+		{14459, []byte{0x38, 0x7b}},
+	}
+
+	for _, test := range tests {
+		rv, err := NewValue(test.value)
+		assert.Nil(t, err)
+
+		bytes, err := rv.MarshalBinary()
+		assert.Nil(t, err)
+		assert.Equal(t, test.expected, bytes)
+	}
+}
+
 func TestMBAP(t *testing.T) {
 	tests := []struct {
 		mbap MBAP

--- a/server.go
+++ b/server.go
@@ -86,7 +86,6 @@ func (s *Server) readMessage(r *bufio.Reader) ([]byte, error) {
 	}
 
 	return buf, nil
-
 }
 
 func (s *Server) executeAndRespond(conn io.Writer, req *Request) error {


### PR DESCRIPTION
Modbus supports 16 bits values. Depending on how one interpret a 16 bit
value, a 16 bit value can represent all values in range of -32768
through 65535.

Goldfish used int16 for values. The problem is that int16 only can take
values in range of -32768 through 32767. Making it not possible to work
in the handlers with the values in range 32768 through 65535.

To solve this a new Value type has been introduced. It's can hold all
values in range of -32768 through 65535.

The signature of goldfish.NewReadHandler() and
goldfish.NewWriteHandler() has been changed to reflects these changes.

Issues: #10