### PR TITLE
Add Value type to support unsigned values

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # Goldfish
 
-Goldfish is a Go package for creating Modbus servers. See
+Goldfish is a Go package for creating Modbus TCP servers. See
 [example/main.go][example] for an example.
 
 ## License

--- a/example/main.go
+++ b/example/main.go
@@ -16,10 +16,15 @@ import (
 //
 // The handler must return a slice representing the values of the requested
 // addresses like [0, 1, 0, 1, 0, 1].
-func handleReadCoils(unitID, start, quantity int) ([]int16, error) {
-	coils := make([]int16, quantity)
+func handleReadCoils(unitID, start, quantity int) ([]modbus.Value, error) {
+	coils := make([]modbus.Value, quantity)
 	for i := 0; i < quantity; i++ {
-		coils[i] = int16((i + start) % 2)
+		v, err := modbus.NewValue((i + start) % 2)
+		if err != nil {
+			return coils, modbus.SlaveDeviceFailureError
+		}
+
+		coils[i] = v
 	}
 
 	return coils, nil
@@ -33,20 +38,25 @@ func handleReadCoils(unitID, start, quantity int) ([]int16, error) {
 //
 // The handler must return a slice with the values of the registers like
 // [31, 298, 1999].
-func handleRegisters(unitID, start, quantity int) ([]int16, error) {
-	registers := make([]int16, quantity)
-	for i := 0; i <= quantity; i++ {
-		registers[i] = int16(i)
+func handleRegisters(unitID, start, quantity int) ([]modbus.Value, error) {
+	registers := make([]modbus.Value, quantity)
+	for i := 0; i < quantity; i++ {
+		v, err := modbus.NewValue(i + start)
+		if err != nil {
+			return registers, modbus.SlaveDeviceFailureError
+		}
+
+		registers[i] = v
 	}
 
 	return registers, nil
 }
 
-func handleWriteRegisters(unitID, start int, values []int16) error {
+func handleWriteRegisters(unitID, start int, values []modbus.Value) error {
 	return nil
 }
 
-func handleWriteCoils(unitID, start int, values []int16) error {
+func handleWriteCoils(unitID, start int, values []modbus.Value) error {
 	if start == 1 {
 		return modbus.IllegalAddressError
 	}
@@ -65,8 +75,8 @@ func main() {
 
 	s.Handle(modbus.ReadCoils, modbus.NewReadHandler(handleReadCoils))
 	s.Handle(modbus.ReadHoldingRegisters, modbus.NewReadHandler(handleRegisters))
-	s.Handle(modbus.WriteSingleCoil, modbus.NewWriteHandler(handleWriteCoils))
-	s.Handle(modbus.WriteSingleRegister, modbus.NewWriteHandler(handleWriteRegisters))
+	s.Handle(modbus.WriteSingleCoil, modbus.NewWriteHandler(handleWriteCoils, modbus.Signed))
+	s.Handle(modbus.WriteSingleRegister, modbus.NewWriteHandler(handleWriteRegisters, modbus.Signed))
 
 	s.Listen()
 }

--- a/handler_test.go
+++ b/handler_test.go
@@ -8,12 +8,12 @@ import (
 )
 
 func TestReadHandler(t *testing.T) {
-	h := NewReadHandler(func(unitID, start, quantity int) ([]int16, error) {
+	h := NewReadHandler(func(unitID, start, quantity int) ([]Value, error) {
 		assert.Equal(t, 0, unitID)
 		assert.Equal(t, 5, start)
 		assert.Equal(t, 3, quantity)
 
-		return []int16{0, 1, 1}, nil
+		return []Value{Value{0}, Value{1}, Value{1}}, nil
 	})
 
 	tests := []struct {
@@ -39,12 +39,12 @@ func TestReadHandler(t *testing.T) {
 
 func TestReduce(t *testing.T) {
 	tests := []struct {
-		input    []int16
-		expected []int8
+		input    []Value
+		expected []byte
 	}{
-		{[]int16{0, 1, 1, 1}, []int8{0xe}},
-		{[]int16{1, 0, 1, 0, 1, 0, 1, 0, 1}, []int8{0x1, 0x55}},
-		{[]int16{1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0}, []int8{0x0, 0x1, 0x1}},
+		{[]Value{Value{0}, Value{1}, Value{1}, Value{1}}, []byte{0xe}},
+		{[]Value{Value{1}, Value{0}, Value{1}, Value{0}, Value{1}, Value{0}, Value{1}, Value{0}, Value{1}}, []byte{0x1, 0x55}},
+		{[]Value{Value{1}, Value{0}, Value{0}, Value{0}, Value{0}, Value{0}, Value{0}, Value{0}, Value{1}, Value{0}, Value{0}, Value{0}, Value{0}, Value{0}, Value{0}, Value{0}, Value{0}}, []byte{0x0, 0x1, 0x1}},
 	}
 
 	for _, test := range tests {
@@ -52,14 +52,14 @@ func TestReduce(t *testing.T) {
 	}
 }
 
-func newWriteHandler(t *testing.T, unitID, start int, values []int16, response error) *WriteHandler {
-	return NewWriteHandler(func(u, s int, v []int16) error {
+func newWriteHandler(t *testing.T, unitID, start int, values []Value, response error, s Signedness) *WriteHandler {
+	return NewWriteHandler(func(u, s int, v []Value) error {
 		assert.Equal(t, unitID, u)
 		assert.Equal(t, start, s)
 		assert.Equal(t, values, v)
 
 		return response
-	})
+	}, s)
 }
 
 func TestWriteHandler(t *testing.T) {
@@ -70,22 +70,27 @@ func TestWriteHandler(t *testing.T) {
 	}{
 		{
 			Request{MBAP{}, WriteSingleCoil, []byte{0x0, 0x1, 0x0, 0x0}},
-			newWriteHandler(t, 0, 1, []int16{0}, nil),
+			newWriteHandler(t, 0, 1, []Value{Value{0}}, nil, Signed),
 			[]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x6, 0x0, 0x5, 0x0, 0x01, 0x0, 0x0},
 		},
 		{
 			Request{MBAP{}, WriteSingleCoil, []byte{0x0, 0x1, 0xc, 0x1}},
-			newWriteHandler(t, 0, 1, []int16{1}, IllegalFunctionError),
+			newWriteHandler(t, 0, 1, []Value{Value{1}}, IllegalFunctionError, Signed),
 			[]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x3, 0x0, 0x85, 0x01},
 		},
 		{
-			Request{MBAP{}, WriteSingleRegister, []byte{0x0, 0x1, 0xc, 0x78}},
-			newWriteHandler(t, 0, 1, []int16{3192}, nil),
-			[]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x6, 0x0, 0x6, 0x0, 0x01, 0xc, 0x78},
+			Request{MBAP{}, WriteSingleRegister, []byte{0x0, 0x1, 0xf3, 0x88}},
+			newWriteHandler(t, 0, 1, []Value{Value{-3192}}, nil, Signed),
+			[]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x6, 0x0, 0x6, 0x0, 0x01, 0xf3, 0x88},
+		},
+		{
+			Request{MBAP{}, WriteSingleRegister, []byte{0x0, 0x1, 0xf3, 0x88}},
+			newWriteHandler(t, 0, 1, []Value{Value{62344}}, nil, Unsigned),
+			[]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x6, 0x0, 0x6, 0x0, 0x01, 0xf3, 0x88},
 		},
 		{
 			Request{MBAP{}, WriteSingleRegister, []byte{0x0, 0x1, 0xc, 0x78}},
-			newWriteHandler(t, 0, 1, []int16{3192}, SlaveDeviceBusyError),
+			newWriteHandler(t, 0, 1, []Value{Value{3192}}, SlaveDeviceBusyError, Signed),
 			[]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x3, 0x0, 0x86, 0x6},
 		},
 	}

--- a/message_test.go
+++ b/message_test.go
@@ -6,6 +6,27 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TesTValue(t *testing.T) {
+	tests := []struct {
+		value    int
+		expected []byte
+	}{
+		{19, []byte{0x0, 0x13}},
+		{-128, []byte{0xff, 0x80}},
+		{-2391, []byte{0xf6, 0xa9}},
+		{14459, []byte{0x38, 0x7b}},
+	}
+
+	for _, test := range tests {
+		rv, err := NewValue(test.value)
+		assert.Nil(t, err)
+
+		bytes, err := rv.MarshalBinary()
+		assert.Nil(t, err)
+		assert.Equal(t, test.expected, bytes)
+	}
+}
+
 func TestMBAP(t *testing.T) {
 	tests := []struct {
 		mbap MBAP

--- a/server.go
+++ b/server.go
@@ -86,7 +86,6 @@ func (s *Server) readMessage(r *bufio.Reader) ([]byte, error) {
 	}
 
 	return buf, nil
-
 }
 
 func (s *Server) executeAndRespond(conn io.Writer, req *Request) error {


### PR DESCRIPTION
Modbus supports 16 bits values. Depending on how one interpret a 16 bit
value, a 16 bit value can represent all values in range of -32768
through 65535.

Goldfish used int16 for values. The problem is that int16 only can take
values in range of -32768 through 32767. Making it not possible to work
in the handlers with the values in range 32768 through 65535.

To solve this a new Value type has been introduced. It's can hold all
values in range of -32768 through 65535.

The signature of goldfish.NewReadHandler() and
goldfish.NewWriteHandler() has been changed to reflects these changes.

Issues: #10