### PR TITLE
This commit  fixes timeout issues.

### DIFF
--- a/server.go
+++ b/server.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"net"
+	"time"
 )
 
 // Server is a Modbus server listens on a port and responds on incoming Modbus
@@ -14,7 +15,7 @@ import (
 type Server struct {
 	l        net.Listener
 	handlers map[uint8]Handler
-
+	timeout  time.Duration
 	ErrorLog *log.Logger
 }
 
@@ -27,24 +28,34 @@ func NewServer(address string) (*Server, error) {
 
 	return &Server{
 		l:        l,
+		timeout:  0,
 		handlers: make(map[uint8]Handler),
 	}, nil
+}
+
+// SetTimeout sets the timeout, which is the maximum duraion a request can take.
+func (s *Server) SetTimeout(t time.Duration) {
+	s.timeout = t
 }
 
 // Listen start listening for requests.
 func (s *Server) Listen() {
 	for {
 		conn, err := s.l.Accept()
+		if d := s.timeout; d != 0 {
+			conn.SetReadDeadline(time.Now().Add(d))
+		}
+
 		if err != nil {
-			s.logf("golfish: failed to accept incomming connection: %v", err)
+			s.logf("golfish: failed to accept incoming connection: %v", err)
 			continue
 		}
 
 		go func() {
 			if err := s.handleConn(conn); err != nil {
 				s.logf("goldfish: unable to handle request from %v: %v", conn.RemoteAddr(), err)
-
 			}
+
 			if err := conn.Close(); err != nil {
 				s.logf("goldfish: failed to close connection with %v: %v", conn.RemoteAddr(), err)
 			}
@@ -56,6 +67,7 @@ func (s *Server) handleConn(conn io.ReadWriteCloser) error {
 	r := bufio.NewReader(conn)
 	for {
 		buf, err := s.readMessage(r)
+
 		if err != nil {
 			// An EOF error indicates the connection did not send new data. This
 			// means the connection can be closed, but its not an error in the program.

--- a/server.go
+++ b/server.go
@@ -42,13 +42,18 @@ func (s *Server) SetTimeout(t time.Duration) {
 func (s *Server) Listen() {
 	for {
 		conn, err := s.l.Accept()
-		if d := s.timeout; d != 0 {
-			conn.SetReadDeadline(time.Now().Add(d))
-		}
 
 		if err != nil {
 			s.logf("golfish: failed to accept incoming connection: %v", err)
 			continue
+		}
+		if d := s.timeout; d != 0 {
+			if err := conn.SetReadDeadline(time.Now().Add(d)); err != nil {
+				s.logf("goldfish: failed set timeout %v: %v", conn.RemoteAddr(), err)
+				if err := conn.Close(); err != nil {
+					s.logf("goldfish: failed to close connection with %v: %v", conn.RemoteAddr(), err)
+				}
+			}
 		}
 
 		go func() {

--- a/server_test.go
+++ b/server_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -21,6 +22,15 @@ type RawHandler struct {
 
 func (h RawHandler) ServeModbus(w io.Writer, r Request) {
 	h.handle(w, r)
+}
+
+func TestSetTimeout(t *testing.T) {
+	s, err := NewServer(":")
+	assert.Nil(t, err)
+	assert.Equal(t, 0*time.Second, s.timeout)
+
+	s.SetTimeout(5 * time.Second)
+	assert.Equal(t, 5*time.Second, s.timeout)
 }
 
 // Connection is a struct implemention the io.ReadWriteCloser interface.


### PR DESCRIPTION
The server did not implement any sort of timeout. Therefore connections
could stay alive forever, while new connections get added all the time.
This would cause crashes in applications using goldfish.

This commit adds an optional, configurable timeout to the server. This
is done in such a way that the API is fully backwards compatible.